### PR TITLE
Fix go vet issue.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,6 @@ Use
 
      http.Handle("/",
         http.FileServer(
-        &assetfs.AssetFS{Asset, AssetDir, "data"}))
+        &assetfs.AssetFS{Asset: Asset, AssetDir: AssetDir, Prefix: "data"}))
 
 to serve files embedded from the `data` directory.

--- a/doc.go
+++ b/doc.go
@@ -9,5 +9,5 @@
 // use:
 //     http.Handle("/",
 //        http.FileServer(
-//        &assetfs.AssetFS{Asset, AssetDir, "data"}))
+//        &assetfs.AssetFS{Asset: Asset, AssetDir: AssetDir, Prefix: "data"}))
 package assetfs


### PR DESCRIPTION
Fix "assetfs.AssetFS composite literal uses unkeyed fields" issue.
