### PR TITLE
fix issue with responding 304 (Not modified)

### DIFF
--- a/assetfs.go
+++ b/assetfs.go
@@ -13,6 +13,10 @@ import (
 	"time"
 )
 
+var (
+	fileTimestamp = time.Now()
+)
+
 // FakeFile implements os.FileInfo interface for a given path and size
 type FakeFile struct {
 	// Path is the path of this file
@@ -37,7 +41,7 @@ func (f *FakeFile) Mode() os.FileMode {
 }
 
 func (f *FakeFile) ModTime() time.Time {
-	return time.Unix(0, 0)
+	return fileTimestamp
 }
 
 func (f *FakeFile) Size() int64 {


### PR DESCRIPTION
in https://github.com/graphite-ng/carbon-relay-ng/issues/30 there is issue with serving old data even if it was changed
it seems that not giving reasonable ModTime makes http.FileServer to do some optimisation.
