### PR TITLE
Remove fmt calls and dependency

### DIFF
--- a/assetfs.go
+++ b/assetfs.go
@@ -3,7 +3,6 @@ package assetfs
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -102,7 +101,6 @@ func NewAssetDirectory(name string, children []string, fs *AssetFS) *AssetDirect
 }
 
 func (f *AssetDirectory) Readdir(count int) ([]os.FileInfo, error) {
-	fmt.Println(f, count)
 	if count <= 0 {
 		return f.Children, nil
 	}


### PR DESCRIPTION
In the name of "Silence is golden".

I don't think that as a library, this should be printing anything to `stdout` or `stderr`, this simply clutters up logs for long running processes, and the print itself isn't wildly useful. (I guess an artifact from dev).