### PR TITLE
Add support for go-bindata's -debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,6 @@ use
      ...
      http.Handle("/",
         http.FileServer(
-        &assetfs.AssetFS{Asset: Asset, AssetDir: AssetDir, Prefix: "data"}))
+        &assetfs.AssetFS{Asset: Asset, AssetDir: AssetDir, Prefix: "data", Debug: "false"}))
 
 to serve files embedded from the `data` directory.

--- a/doc.go
+++ b/doc.go
@@ -9,5 +9,5 @@
 // use:
 //     http.Handle("/",
 //        http.FileServer(
-//        &assetfs.AssetFS{Asset: Asset, AssetDir: AssetDir, Prefix: "data"}))
+//        &assetfs.AssetFS{Asset: Asset, AssetDir: AssetDir, Prefix: "data", Debug: false}))
 package assetfs


### PR DESCRIPTION
Currently, go-bindata-assetfs with -debug does not work as expected. Because FakeFile's ModTime() is static, changes won't be loaded by the http server without a restart (even though (fs *AssetFS) Open causes the file to be read again.) This pull request modifies the library and the tool to use the -debug option.

I didn't want to break the API, so I kept things pretty simple. If the Debug option is true, then ModTime() returns time.Now() instead of the static time set at startup. Thus the http server doesn't cache any files, and any changes will be sent to the client. It could be more efficient by actually checking the modtime of the file, but that would require a lot more code and complexity and I figure the most common use case of -debug is running on localhost anyways (plus the file is read every time anyways.)

The pull request is split into separate commits for the library and the tool.

If this request is not acceptable, please let me know how I can work with you to get it accepted.