### PR TITLE
add support for -debug (2nd try)

### DIFF
--- a/go-bindata-assetfs/main.go
+++ b/go-bindata-assetfs/main.go
@@ -3,12 +3,30 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"flag"
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 )
 
 const bindatafile = "bindata.go"
+
+func isDebug(args []string) bool {
+	flagset := flag.NewFlagSet("", flag.ContinueOnError)
+	debug := flagset.Bool("debug", false, "")
+	debugArgs := make([]string, 0)
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "-debug") {
+			debugArgs = append(debugArgs, arg)
+		}
+	}
+	flagset.Parse(debugArgs)
+	if debug == nil {
+		return false
+	}
+	return *debug
+}
 
 func main() {
 	if _, err := exec.LookPath("go-bindata"); err != nil {
@@ -33,6 +51,7 @@ func main() {
 		fmt.Fprintln(os.Stderr, "Cannot write 'bindata_assetfs.go'", err)
 		return
 	}
+	debug := isDebug(os.Args[1:])
 	r := bufio.NewReader(in)
 	done := false
 	for line, isPrefix, err := r.ReadLine(); err == nil; line, isPrefix, err = r.ReadLine() {
@@ -42,17 +61,31 @@ func main() {
 			return
 		}
 		if !done && !isPrefix && bytes.HasPrefix(line, []byte("import (")) {
-			fmt.Fprintln(out, "\t\"github.com/elazarl/go-bindata-assetfs\"")
+			if debug {
+				fmt.Fprintln(out, "\t\"net/http\"")
+			} else {
+				fmt.Fprintln(out, "\t\"github.com/elazarl/go-bindata-assetfs\"")
+			}
 			done = true
 		}
 	}
-	fmt.Fprintln(out, `
+	if debug {
+		fmt.Fprintln(out, `
+func assetFS() http.FileSystem {
+	for k := range _bintree.Children {
+		return http.Dir(k)
+	}
+	panic("unreachable")
+}`)
+	} else {
+		fmt.Fprintln(out, `
 func assetFS() *assetfs.AssetFS {
 	for k := range _bintree.Children {
 		return &assetfs.AssetFS{Asset: Asset, AssetDir: AssetDir, Prefix: k}
 	}
 	panic("unreachable")
 }`)
+	}
 	// Close files BEFORE remove calls (don't use defer).
 	in.Close()
 	out.Close()


### PR DESCRIPTION
This is a follow up to PR #9. For rationale please see that PR.
After reading @shurcooL's comments on PR #9, I realized that I made things way to complicated and using `http.Dir` instead of monkeying around with the library is much simpler and better since it can send HTTP 304s.
I'm closing that PR in favor of this one.
Thanks!