### PR TITLE
fix writing newline before buffer reads to next line

### DIFF
--- a/go-bindata-assetfs/main.go
+++ b/go-bindata-assetfs/main.go
@@ -36,7 +36,9 @@ func main() {
 	r := bufio.NewReader(in)
 	done := false
 	for line, isPrefix, err := r.ReadLine(); err == nil; line, isPrefix, err = r.ReadLine() {
-		line = append(line, '\n')
+		if !isPrefix {
+			line = append(line, '\n')
+		}
 		if _, err := out.Write(line); err != nil {
 			fmt.Fprintln(os.Stderr, "Cannot write to 'bindata_assetfs.go'", err)
 			return


### PR DESCRIPTION
It's me again with an actual bug this time.

Always writing `\n` without checking for `isPrefix` was causing the `[]byte`s  with large amounts of data to be split by `\n` leading to unterminated strings.

Per the docs:

> ReadLine tries to return a single line, not including the end-of-line bytes. If the line was too long for the buffer then isPrefix is set and the beginning of the line is returned. The rest of the line will be returned from future calls. isPrefix will be false when returning the last fragment of the line.

I'm submitting this PR even though you haven't accepted the other one yet because they should both merge in either order. If it becomes a problem feel free to apply the patch yourself.

Thanks!