### PR TITLE
Fix build for go tip (a.k.a. go 1.5).

### DIFF
--- a/assetfs.go
+++ b/assetfs.go
@@ -73,6 +73,10 @@ func (f *AssetFile) Readdir(count int) ([]os.FileInfo, error) {
 	return nil, errors.New("not a directory")
 }
 
+func (f *AssetFile) Size() int64 {
+	return f.FakeFile.Size()
+}
+
 func (f *AssetFile) Stat() (os.FileInfo, error) {
 	return f, nil
 }


### PR DESCRIPTION
In go 1.5 bytes.Reader defines a Size method which causes ambiguity when
embedding both bytes.Reader and FakeFile in AssetFile. Manually resolve
the ambiguity about which Size method to use.