### PR TITLE
Check Asset before AssetDir

### DIFF
--- a/assetfs.go
+++ b/assetfs.go
@@ -136,12 +136,12 @@ func (fs *AssetFS) Open(name string) (http.File, error) {
 	if len(name) > 0 && name[0] == '/' {
 		name = name[1:]
 	}
+	if b, err := fs.Asset(name); err == nil {
+		return NewAssetFile(name, b), nil
+	}
 	if children, err := fs.AssetDir(name); err == nil {
 		return NewAssetDirectory(name, children, fs), nil
-	}
-	b, err := fs.Asset(name)
-	if err != nil {
+	} else {
 		return nil, err
 	}
-	return NewAssetFile(name, b), nil
 }


### PR DESCRIPTION
The go-bindata `Asset` check is much cheaper than the `AssetDir` check (map lookup vs tree traversal), and I think accessing files is more common than accessing directories when serving files.

This moves the `Asset` check first, and only does the `AssetDir` check if `Asset` returns an error