### PR TITLE
Return os.ErrNotExist if file not found

### DIFF
--- a/assetfs.go
+++ b/assetfs.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -142,6 +143,12 @@ func (fs *AssetFS) Open(name string) (http.File, error) {
 	if children, err := fs.AssetDir(name); err == nil {
 		return NewAssetDirectory(name, children, fs), nil
 	} else {
+		// If the error is not found, return an error that will
+		// result in a 404 error. Otherwise the server returns
+		// a 500 error for files not found.
+		if strings.Contains(err.Error(), "not found") {
+			return nil, os.ErrNotExist
+		}
 		return nil, err
 	}
 }


### PR DESCRIPTION
Currently, if a url is requested for a file that does not exist, a 500 code is returned to the client. This is not desirable.

This small change checks for the text "not found" in the error returned by the go-bindata generated code, and if so returns os.ErrNotExist. This will result in a 404 message.

Checking for the text "not found" in the error returned by the go-bindata code is not ideal as it is brittle, but that code is pretty stable. It's better than returning an internal server error (500).