### PR TITLE
Include AssetInfo assignment in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,6 @@ use
      ...
      http.Handle("/",
         http.FileServer(
-        &assetfs.AssetFS{Asset: Asset, AssetDir: AssetDir, Prefix: "data"}))
+        &assetfs.AssetFS{Asset: Asset, AssetDir: AssetDir, AssetInfo: AssetInfo, Prefix: "data"}))
 
 to serve files embedded from the `data` directory.


### PR DESCRIPTION
"Without running binary tool" example didn't include assigning AssetInfo to AssetFS struct.