### PR TITLE
Parse the output location for bindatafile

### DIFF
--- a/go-bindata-assetfs/main.go
+++ b/go-bindata-assetfs/main.go
@@ -33,7 +33,7 @@ func getBinDataFile() string {
 		}
 	}
 
-	return "bindatafile.go"
+	return "bindata.go"
 }
 
 func main() {


### PR DESCRIPTION
The expected file location was hard coded even though it is possible to change it. Added code to potentially parse the output location flag, else the default value is used.