### PR TITLE
This fixes #39 for me: AssetInfo undefined

### DIFF
--- a/go-bindata-assetfs/main.go
+++ b/go-bindata-assetfs/main.go
@@ -67,6 +67,7 @@ func main() {
 				fmt.Fprintln(out, "\t\"net/http\"")
 			} else {
 				fmt.Fprintln(out, "\t\"github.com/elazarl/go-bindata-assetfs\"")
+				fmt.Fprintln(out, "\t\"os\"")
 			}
 			done = true
 		}
@@ -82,8 +83,11 @@ func assetFS() http.FileSystem {
 	} else {
 		fmt.Fprintln(out, `
 func assetFS() *assetfs.AssetFS {
+	assetInfo := func(path string) (os.FileInfo, error) {
+		return os.Stat(path)
+	}
 	for k := range _bintree.Children {
-		return &assetfs.AssetFS{Asset: Asset, AssetDir: AssetDir, AssetInfo: AssetInfo, Prefix: k}
+		return &assetfs.AssetFS{Asset: Asset, AssetDir: AssetDir, AssetInfo: assetInfo, Prefix: k}
 	}
 	panic("unreachable")
 }`)


### PR DESCRIPTION
Before, I could not compile programs that included the generated
file bindata_assetfs.go due an undefined element AssetInfo. This
is supposed to be a function that returns an os.FileInfo object
that just seemed to be missing.