### PR TITLE
Remove extra os package import, fixes #41

### DIFF
--- a/go-bindata-assetfs/main.go
+++ b/go-bindata-assetfs/main.go
@@ -67,7 +67,6 @@ func main() {
 				fmt.Fprintln(out, "\t\"net/http\"")
 			} else {
 				fmt.Fprintln(out, "\t\"github.com/elazarl/go-bindata-assetfs\"")
-				fmt.Fprintln(out, "\t\"os\"")
 			}
 			done = true
 		}


### PR DESCRIPTION
See issue #41 description. `go_bindata` should already always produce an `os` import and the one added by `go_bindata_assetfs` causes a compile time error.