### PR TITLE
feat(spa): fallback for single page applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,26 @@ You can always just run the `go-bindata` tool, and then
 
 use
 
-     import "github.com/elazarl/go-bindata-assetfs"
-     ...
-     http.Handle("/",
-        http.FileServer(
-        &assetfs.AssetFS{Asset: Asset, AssetDir: AssetDir, AssetInfo: AssetInfo, Prefix: "data"}))
+```go
+import "github.com/elazarl/go-bindata-assetfs"
+...
+http.Handle("/",
+http.FileServer(
+&assetfs.AssetFS{Asset: Asset, AssetDir: AssetDir, AssetInfo: AssetInfo, Prefix: "data"}))
+```
 
 to serve files embedded from the `data` directory.
+
+## SPA applications
+
+For single page applications you can use `Fallback: "index.html"` in AssetFS context, so if route doesn't match the pattern it will fallback to file specified.
+
+example
+
+```go
+import "github.com/elazarl/go-bindata-assetfs"
+...
+http.Handle("/",
+http.FileServer(
+&assetfs.AssetFS{Asset: Asset, AssetDir: AssetDir, AssetInfo: AssetInfo, Prefix: "data", Fallback: "index.html"}))
+```


### PR DESCRIPTION
In case of SPA apps (Angular, React, Vue, ...) when you hit refresh button and route doesn't match the pattern you can specify fallback file that is served if no other is found. `index.html` in most cases.