### PR TITLE
Test fixes for multiplatform and/or Nix

### DIFF
--- a/go-bindata-assetfs/main_test.go
+++ b/go-bindata-assetfs/main_test.go
@@ -5,12 +5,9 @@ import (
 	"bytes"
 	"os"
 	"reflect"
-	"regexp"
+	"strings"
 	"testing"
 )
-
-var temp_pattern *regexp.Regexp = regexp.MustCompile(`^/tmp/`)
-var exec_pattern *regexp.Regexp = regexp.MustCompile(`go-bindata`)
 
 func helper(t *testing.T, tmp string, args []string) Config {
 	c, err := parseConfig(args)
@@ -22,13 +19,13 @@ func helper(t *testing.T, tmp string, args []string) Config {
 		if c.TempPath != tmp {
 			t.Fatalf("Expected c.TempFile to be %s, got %s", tmp, c.TempPath)
 		}
-	} else if temp_pattern.MatchString(c.TempPath) {
+	} else if strings.HasPrefix(c.TempPath, os.TempDir()) {
 		os.Remove(c.TempPath)
 	} else {
 		t.Fatalf("TempPath should live in system temp directory, got %s", c.TempPath)
 	}
 
-	if !exec_pattern.MatchString(c.ExecPath) {
+	if !strings.HasSuffix(c.ExecPath, "go-bindata") {
 		t.Fatalf("ExecPath should point to go-bindata binary, got %s", c.ExecPath)
 	}
 	return c


### PR DESCRIPTION
I recently had this big PR that expanded the test suite. Pretty great, but...

1. It baked in some assumptions about the system tempdir, and
2. It used regular expressions where the code could be more specific and faster using `strings.*` functions instead.

The latter is just a little annoying, but the former actually breaks when running the test suite in Nix (where the tempdir is usually `/private/tmp/`), and I _imagine_ probably wouldn't work great on Windows. My particular use case is on the Nix side, so it might be a niche issue, but that niche is where I'm living 🤷‍♀️ .

Thankfully the fixes are pretty simple, and should be an easy review.